### PR TITLE
improved resizing on landing page, added to paragraph

### DIFF
--- a/DTC.web/src/pages/Dashboard/Dashboard.css
+++ b/DTC.web/src/pages/Dashboard/Dashboard.css
@@ -35,20 +35,6 @@
   column-gap: 75px;
 }
 
-@media (max-width: 950px) {
-  .landing {
-    justify-content: start;
-    align-items: start;
-  }
-  .landing-text {
-    margin-top: 94px;
-  }
-
-  .landing-decks {
-    margin-top: 33px;
-  }
-}
-
 .landing-text {
   width: 720px;
   font-family: "Arial";
@@ -58,6 +44,7 @@
   margin-bottom: 250px;
   gap: 20px;
   align-items: center;
+  transition: 0.5s;
 }
 
 .landing-heading {
@@ -68,6 +55,7 @@
   background-image: linear-gradient(to left, rgb(90, 53, 163), rgb(225, 101, 250));
   -webkit-background-clip: text; /* For WebKit browsers */
   display: inline-block; /* or 'block' depending on your layout needs */
+  transition: 0.5s;
 }
 
 .landing-paragraph {
@@ -82,8 +70,8 @@
   line-height: 1.5; /* Adjusted to be relative, which is more adaptable */
   font-style: normal; /* For better readability over long texts */
   margin: auto; /* Centers the paragraph if width is less than 100% */
+  transition: 0.5s;
 }
-
 
 .landing-feature {
   color: rgb(146, 142, 129);
@@ -99,4 +87,35 @@
   display: flex;
   flex-direction: column;
   gap: 20px;
+  transition: 0.5s;
+}
+
+@media (max-width: 1300px) {
+  .landing {
+    justify-content: start;
+    flex-direction: column;
+  }
+  .landing-text {
+    padding-top: 60px;
+    transition: 0.5s;
+  }
+  .landing-decks {
+    margin-top: -200px;
+    transition: 0.5s;
+  }
+}
+
+@media (max-width: 650px) {
+  .landing-heading {
+    font-size: 25px;
+  }
+  .landing-text {
+    padding-top: 30px;
+    transition: 0.5s;
+  }
+  .landing-paragraph {
+    max-width: 200px;
+    font-size: 10px;
+    transition: 0.5s;
+  }
 }

--- a/DTC.web/src/pages/Dashboard/Dashboard.jsx
+++ b/DTC.web/src/pages/Dashboard/Dashboard.jsx
@@ -65,9 +65,10 @@ export default function Dashboard() {
       ></DTCHeader>
       <div className="landing">
         <div className="landing-text">
-          <text className="landing-heading">Welcome to DeckTechCentral.</text>
+          <text className="landing-heading">Welcome to DeckTechCentral</text>
           <text className="landing-paragraph">
-            DeckTechCentral is a web based deck management tool for Magic: The Gathering.
+            DeckTechCentral is a web based deck management tool for Magic: The Gathering. 
+            Explore our collection of user-made decks or create your own ultimate decks!
           </text>
         </div>
         <div className="landing-decks">


### PR DESCRIPTION
I improved the resizing so that the elements are still on screen when the page gets smaller. 

I added another sentence to the landing paragraph. I'm thinking now that we should keep this short, as we don't want to bombard the user with text when they go to the page. Maybe we could have an "About" page with more information about DTC, who we are, links to Magic resources, etc. Then again that might be what the user manual is supposed to serve as.